### PR TITLE
Add ORC WG Comment Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Home of the Open Regulatory Compliance Working Group (ORC WG) of the Eclipse Fou
 
 * [Cyber Resilience SIG](https://github.com/orcwg/cyber-resilience-sig/)
 
+
 ## CRA Hub
 
 * FAQ
@@ -17,6 +18,7 @@ Home of the Open Regulatory Compliance Working Group (ORC WG) of the Eclipse Fou
 * [Working Group Charter]()
 * [Antitrust Policy](https://www.eclipse.org/org/documents/Eclipse_Antitrust_Policy.pdf)
 * [Code of Conduct](https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php)
+* [ORC WG Comment Process](./processes/orc-wg-comment-process.md)
 
 ## Get involved
 

--- a/orc-wg-comments/README.md
+++ b/orc-wg-comments/README.md
@@ -1,0 +1,9 @@
+# ORC WG Comments
+
+_ORC WG Comments_ listed in the table below have gone through the [ORC WG Comment Process](../processes/orc-wg-comment-process.md).
+As such they represent working group consensus and can be shared, referenced, and quoted as such.
+
+| Link to _ORC WG Comment_ | Date submmitted | Date approved | Link to mailing list review request |
+| ---- | ----------------- | ------------- | ----------------------------------- |
+|      |                   |               |                                     |
+

--- a/processes/orc-wg-comment-process.md
+++ b/processes/orc-wg-comment-process.md
@@ -1,0 +1,25 @@
+## ORC WG Comment Process
+
+## Context
+
+In order to successfully execute on its mission, the ORC WG needs to provide timely input to various requests from institutions, standard setting organizations, and other relevant stakeholders. These input requests usually have a much shorter turnaround time than would be possible to achieve through the [Eclipse Foundation Specification Process (EFSP)][EFSP]. The expected responses to these requests are also not specifications, and calling them as such would risk diluting the gravitas of the foundation’s formal spec process. Yet, responses made by the working group need to reflect some sense of working group consensus. Hence the need for a process that's faster than the EFPS, but more representative of the working group’s consensus than a staff update.
+
+
+## ORC WG Comment
+
+An _ORC WG Comment_ is a comment made by the working group to an external stakeholder that reflects working group consensus. To represent working group consensus, a working group comment must follow the following process.
+
+1. A pull request of the proposed _ORC WG Comment_ is made against the `orc-wg-comment` folder on this repository by the comment’s author.
+2. The _ORC WG Comment_ author sends an email to <open-regulatory-compliance@eclipse.org> with subject line `[ORC WG Comment review request]` to request a review from the working group. This kicks off a 1-week review period during which everyone is invited to make comments and propose edits directly on GitHub.
+3. Once all of the following conditions are met the _ORC WG Comment_ can be merged in the repository and represents _working group consensus_:
+   
+   1. the review period is over,
+   2. a positive review threshold of 5 reviews is met,
+   3. there are no remaining change requests from working group members, and
+   4. the author has addressed every review comment they committed to address.
+   
+   Once the _ORC WG Comment_ has been merged it can be shared with external stakeholders as representative of the working group’s position on a topic.
+4. If the author fails to address change requests by working group members to their satisfaction or if the pull request hasn’t met the positive review threshold, the pull request cannot be merged and the content of the proposed _ORC WG Comment_ cannot be used to represent working group consensus.
+5. Working group members who make a change request to a proposed _ORC WG Comment_ are expected to participate in the process in good faith in order to arrive at a consensus. Their change request may be overruled by the Steering Committee if the Steering Committee believes they are not acting in good faith.
+
+[EFSP]: https://www.eclipse.org/projects/efsp/


### PR DESCRIPTION
The ORC WG needs to provide timely input to various requests from institutions, standard setting organizations, and other relevant stakeholders. These input requests usually have a much shorter turnaround time than would be possible to achieve through the Eclipse Foundation Specification Process (EFSP). The expected responses to these requests are also not specifications, and calling them as such would risk diluting the gravitas of the foundation’s formal spec process. Yet, responses made by the working group need to reflect some sense of working group consensus.

The process outlined in this pull request proposes a solution to do just that. It would need to be and discussed by the Steering Committee and formally approved.