### PR TITLE
Add pillars to draft program plan

### DIFF
--- a/program-plan.md
+++ b/program-plan.md
@@ -34,7 +34,7 @@ Develop the technical assets that will be shared with the Standardization bodies
 | Key metrics                              | 2024 | 2025 |
 | :--------------------------------------- | ---: | ---: |
 | Percentage of complete CRA deliverables. |   0% |  20% |
-| Number of discrete WG deliverables adopted by independent organizations<br>_(For example, if one spec is adopted by 8 orgs and another spec is adopted by 5, the total is 13)) | 0 | 100 |
+| Number of discrete WG deliverables adopted by independent organizations<br>_(For example, if one spec is adopted by 8 orgs and another spec is adopted by 5, the total is 13.)_ | 0 | 100 |
 
 #### Activities
 

--- a/program-plan.md
+++ b/program-plan.md
@@ -1,0 +1,81 @@
+# ORC WG Program Pillars
+
+* 🎓 [Awareness, Education and Thought Leadership](#-awareness-education-and-thought-leadership)
+* 🧑‍💻 [Technical Development](#-technical-development)
+* 🏛️ [Institutional Engagement](#%EF%B8%8F-institutional-engagement)
+* 🤝 [Community Representation](#-community-representation)
+
+
+## 🎓 Awareness, Education and Thought Leadership
+
+Close the knowledge gap and demonstrate ORC WG as the reference source of information in all the subjects related to regulatory compliance and open source worldwide.
+
+| Key metrics                                                      | 2024 | 2025 |
+| :--------------------------------------------------------------- | ---: | ---: |
+| Questions about the CRA answered by linking to WG content        |   0% |  80% |
+| Number of followers/subscribers to ORC WG communication channels |  190 | 2500 |
+| Public presentations by ORC WG members & EF staff per year       |  ~20 |   50 |
+
+
+#### Activities
+
+
+* Identify gaps in educational resources and training materials to support open source community in understanding and implementing compliant development practices.
+* Develop specific assets for the different stakeholders to understand the current regulatory scene and to promote the adoption of the results of the WG.
+* Analyzing emerging regulation in the digital space, their impact to the Open Source Community and how they can be integrated into WG activities.
+* Allocate relevant regulatory frameworks under the scope of the different projects and SIGs inside the WG and in case there is no specific activity to cover them, propose the creation of a new workstream dedicated to it. 
+* Cooperation between OSPOs of the WG Members and  Stewards to ensure processes proposed by tbe WG serve the overall needs of industry, including both large companies and SMEs, making adoption by them of upstream open source projects more valuable and streamlined, and to better help them meet key requirements such as attestations.
+
+
+## 🧑‍💻 Technical Development
+
+Develop the technical assets that will be shared with the Standardization bodies to support the open source community in the process of be compliant with the existing and emerging regulation.
+
+| Key metrics                              | 2024 | 2025 |
+| :--------------------------------------- | ---: | ---: |
+| Percentage of complete CRA deliverables. |   0% |  20% |
+| Number of discrete WG deliverables adopted by independent organizations<br>_(For example, if one spec is adopted by 8 orgs and another spec is adopted by 5, the total is 13)) | 0 | 100 |
+
+#### Activities
+
+* Capture state of the art of open source projects including best practices, processes, tools.
+* Identify the needs for new software development processes and where they are best developed.
+* Development of specifications addressing the regulatory requirements.
+* Develop proposals and input to standardization bodies and institutions.
+
+
+## 🏛️ Institutional Engagement
+
+Strengthen the cooperation and relationship with the public administrations and regulatory bodies to build a bidirectional communication enabling a continuous exchange.
+
+| Key metrics                                                        | 2024 | 2025 |
+| :----------------------------------------------------------------- | ---: | ---: |
+| Number of working relationship with Institutions (NSB, SDOs, etc.) |    2 |   12 |
+| Number of ORC WG Comments contributed to institutions              |    0 |   12 |
+
+#### Activities
+
+* Establish the Government Observatory Forum to set a common space for regulatory authorities exchange, and collect institutional feedback for the community.
+* Engage and cooperate with standardization bodies (NSBs, ESOs, ISO, etc.) to support the adoption of the proposals created by the WG.
+* Coordinate WG member activities in standardization bodies (NSBs, ESOs, ISO, etc.).
+* Monitoring regulatory initiatives affecting open source and digital products worldwide to fit those who are relevant within the scope of this WG.
+
+
+## 🤝 Community Representation
+
+Build legitimacy through broad stakeholder representation, growing ORC WG membership and contributor base.
+
+| Key metrics                                                                        | 2024 | 2025 |
+| :--------------------------------------------------------------------------------- | ---: | ---: |
+| Total number of members                                                            |   29 |  100 |
+| Number of members that are SMEs                                                    |    5 |   50 |
+| Number of individual contributors to GitHub<br>_(Includes issues, comments, etc.)_ |    0 |  800 |
+
+#### Activities
+
+* Address internal stakeholders groups to promote WG results and engage new entities in the ORC WG activities.
+* Development of events to promote WG activities focusing on raising awareness within the Open Source Community of the impact of the regulation.
+* Stakeholder surveys and feedback mechanisms to engage deeper with the WG members and relevant stakeholders. 
+* Broaden diversity of membership.
+* Build cooperation with relevant stakeholder organizations.
+


### PR DESCRIPTION
Turning the draft program plan into a markdown document to get a better feel for it.

This only includes the proposed pillars for now.

For reference, here the [rendered MD file](https://github.com/orcwg/orcwg/blob/tobie-program-plan/program-plan.md).