### PR TITLE
Update to SIG minutes

### DIFF
--- a/cyber-resilience-sig/minutes/2025-02-17-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-02-17-mom-cyber-resilience-sig.md
@@ -1,6 +1,11 @@
-# **Open Regulatory Compliance Working Group** Cyber Resilience SIG
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-02-17
+Approved: 2025-03-03
+---
 
-###  17 February 2025
 ##  Agenda
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
@@ -12,8 +17,7 @@
 | Deliverable plan | Tobie | 5 |
 | AOB | | 5 |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
 
 * Juan Rico (Eclipse Foundation)  
 * Tobie Langel (Eclipse Foundation)
@@ -49,7 +53,7 @@
 * Maxim Baele (OWASP)  
 * Pierre Pochery (FreeBSD Foundation)  
 * Thierry Carrez (OpenStack)
-</details> 
+
 
 ## Minutes
 ### FOSDEM & Workshop output 

--- a/cyber-resilience-sig/minutes/2025-03-03-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-03-03-mom-cyber-resilience-sig.md
@@ -1,6 +1,11 @@
- **Open Regulatory Compliance Working Group** Cyber Resilience SIG
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-03-03
+Approved: 2025-03-17
+---
 
-###  3 March 2025
 ##  Agenda
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
@@ -13,9 +18,7 @@
 | Inventory Task Force | Maxim & Tobie | 5 |
 | AOB | | 5 |
 
-## Notes 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
 
 * Juan Rico (Eclipse Foundation)  
 * Tobie Langel (UnlockOpen/Eclipse Foundation)  
@@ -45,7 +48,9 @@
 * Pierre Pochery (FreeBSD Foundation)  
 * Lucia Lanfri (CEN/CENELEC)  
 * Alberto Pianon (Array)
-</details>
+
+
+## Minutes
 
 ### Stakeholder consultation workshop for CRA Standardization
 

--- a/cyber-resilience-sig/minutes/2025-03-17-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-03-17-mom-cyber-resilience-sig.md
@@ -1,7 +1,13 @@
- **Open Regulatory Compliance Working Group** Cyber Resilience SIG
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-03-17
+Approved: 2025-03-31
+---
 
-###  17 March 2025
 ##  Agenda
+
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
 | Approve [previous minutes](https://github.com/orcwg/orcwg/pull/48) | Juan | 2 |
@@ -13,8 +19,7 @@
 | Task Force updates:<li>[FAQ](https://github.com/orgs/orcwg/projects/7)<li>Inventory | Tobie | 5 |
 | AOB | | 3 |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
  
 * Tobie Langel (UnlockOpen / Eclipse Foundation  
 * Juan Rico (Eclipse Foundation)  
@@ -42,16 +47,16 @@
 * Michael Schuster (BSI)  
 * Sal Kimmich  
 * Seth Larson
-</details>
 
-Notes:
 
-## Approve previous minutes
+## Minutes
+
+### Approve previous minutes
 
 * [previous minutes](https://github.com/orcwg/orcwg/pull/48)  
 * Approved
 
-## Steering & Spec Committee updates
+### Steering & Spec Committee updates
 
 * Deliverables Plan approved  
 * Cyber Resilience Practices Project in ballot  
@@ -62,7 +67,7 @@ Notes:
 * Leadership group consolidated to simplify:  
   * SIG leadership \- Chair and Co-Chair of the Steering Committee and the Chair of the Specification Committee
 
-## Collaboration on BSI (Bundesamtes für Sicherheit in der Informationstechnik) and FSFE questionnaire
+### Collaboration on BSI (Bundesamtes für Sicherheit in der Informationstechnik) and FSFE questionnaire
 
 * Michael Schuster & Alexander Sander  
 * Focus is more on civil society, but includes additional stakeholders  
@@ -72,33 +77,33 @@ Notes:
   * The expected outcome from the survey is not only answers but also new questions to provide guidance.  
   * Common effort aligning this survey with the FAQ, and consulting them to the CRA Expert Group and the EC as a potential way forward.
 
-## Technical definitions of Important & Critical Products
+### Technical definitions of Important & Critical Products
 
 * [Proposal](https://github.com/orcwg/cra-hub/blob/tobie-prod-reg/product-definitions/README.md#current-consultations)  
 * [Related pull request](https://github.com/orcwg/cra-hub/pull/164)  
 * It was presented the methodology to work on the proposal, submitting comments via pull request.  
 * As a note: The definitions could be amended by other European laws, not only the CRA.
 
-## Collaboration with the EU Commission
+### Collaboration with the EU Commission
 
 * Presented to the EC the Deliverable Plan with positive feedback.  
 * It was suggested to have a joint brainstorming as each deliverable is started, and when the first draft is ready.  
 * It is necessary to create an explainer for each deliverable to present them to ETSI and CEN/CENELEC \- simplifying people to understand the work we are doing.  
 * **EXPLAINER** concept \- high level description of 1 page describing what the next piece of work will look like.
 
-## Task force on advocacy / thought leadership?
+### Task force on advocacy / thought leadership?
 
 * [Related issue](https://github.com/orcwg/orcwg/issues/52#issuecomment-2723901813)  
 * Usage of the potential fines \- propose to take that money back to the open source community by setting a Soverign tech fund.  
 * Public access to the aggregated SBOMs \- [https://github.com/orcwg/orcwg/issues/52\#issuecomment-2723901813](https://github.com/orcwg/orcwg/issues/52#issuecomment-2723901813)   
 * People interested to reach out either in the issues, slack or any other mean
 
-## Task Force updates
+### Task Force updates
 
 * [FAQ](https://github.com/orgs/orcwg/projects/7)  
 * Inventory
 * No progress on this area in the last two weeks.
 
-## AOB
+### AOB
 
 * Proposal: Add a standing point “Reports from other projects and organisations” where we get VERY SHORT updates and pointers to more information

--- a/cyber-resilience-sig/minutes/2025-03-31-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-03-31-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  31 March 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-03-31
+Approved: 2025-04-28
+---
+
 ##  Agenda
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
@@ -11,8 +18,7 @@
 | [Vulnerability Management Specification](https://github.com/orcwg/vulnerability-management-spec) | Mikael | 10 |
 | AOB | | 5 |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
  
  * Tobie Langel (UnlockOpen/Eclipse Foundation)  
  * Mathias Schindler (Github)  
@@ -33,9 +39,9 @@
 * Timo Perälä (Nokia)  
 * Dirk-Willem van Gulik (ASF)  
 * Vicky Risk (ISC)
-</details>
 
-## Notes
+
+## Minutes
 
 ### Approve previous minutes
 

--- a/cyber-resilience-sig/minutes/2025-04-14-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-04-14-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  14 April 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-04-14
+Approved: 2025-04-28
+---
+
 ##  Agenda
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
@@ -10,8 +17,7 @@
 | Deliverables Plan | Tobie |10 |
 | AOB | | 5 |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
  
 * Tobie Langel (UnlockOpen / Eclipse)  
 * Juan Rico (Eclipse Foundation)  
@@ -41,13 +47,14 @@
 * Aeva Black  
 * Sal Kimmich
   
- </details>
 
 
-## Notes
+
+## Minutes
 
 ### Approve previous minutes  
   * Will approve next call  
+
 ### Steering and Specification Committees Coordination  
   * Steering Committee update  
     * Meeting this week \- no updates.
@@ -64,7 +71,8 @@
     * Still requires some internal steps.  
   * ORC WG member who would like to handle liaison with OpenSSF  
     * It will be done through the members.  
-### CRA Mondays  
+
+### CRA Mondays
   * What’s this new thing?  
     * Adjacent topics that we care about  
   * How can we suggest topics and guests? [cra-mondays](https://github.com/orcwg/orcwg/labels/cra-mondays) label on orcwg/orcwg  
@@ -72,6 +80,7 @@
   * Is it being recorded?  
     * Yes  
   * What’s today’s topic?  
+
 ### Product definitions ([open issues and PRs](https://github.com/orcwg/cra-hub/pulls?q=is:pr+is:open+label:%22Critical+and+Important+Products%22))  
   * The deadline has been extended until the 18th of April  
   * Covering the open PRs  
@@ -79,6 +88,7 @@
       * To include Trusted Execution Environments  
   * The first discussion took longer than expected so it was decided to follow up asynchronously.  
   * Everyone is allowed to provide feedback to the EC. So for those in which the consensus is weak, it is not going to be submitted as ORC, but entitle everyone to reach out with their feedback to the EC.  
+
 ### Deliverable plan
 * Updated [deliverables plan](https://github.com/orcwg/orcwg/tree/tobie-going-deeper/cyber-resilience-sig#deliverables)  
   * Share plan with community  
@@ -87,8 +97,7 @@
     * Missing liaison with market surveillance in particular for SBOMs  
   * Next SIG call, decide which deliverables to focus on next and create task forces
 
-
-## Actions  
+## Actions
   * Collect feedback from the community the next week --> Deliverbales plan
     * Consolidate in the next SIG Call  
     * Call for volunteers to drive the work  

--- a/cyber-resilience-sig/minutes/2025-04-28-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-04-28-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  28 April 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-04-28
+Approved: 2025-05-12
+---
+
 ##  Agenda
  Agenda Topics | Moderator | Minutes |
 | ----- | ----- | :---: |
@@ -13,8 +20,7 @@
 | Deliverables Plan | Tobie | 20 |
 | AOB | | 5 |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
  
 - Tobie Langel (UnlockOpen/Eclipse)
 - Timo Perälä (Nokia)
@@ -39,10 +45,10 @@
 - Jeremy Stanley (Spec Committee, OpenInfra Foundation, SPI)
 - Daniel Thompson-Yvetot (Tauri)
 
-</details>
 
 
-## Notes
+
+## Minutes
 
 ### Approve previous minutes  
   - Approved, Tobie to merge

--- a/cyber-resilience-sig/minutes/2025-05-12-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-05-12-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  12 May 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-05-12
+Approved: 2025-05-26
+---
+
 ##  Agenda
 | Min | Agenda Topics | Moderator |
 | --: | ----- | --- |
@@ -15,8 +22,7 @@
 |  56 | AOB | |
 
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
  
 * Tobie Langel (UnlockOpen/ Eclipse Foundation)  
 * Daniel Thompson-Yvetot (Tauri)  
@@ -39,8 +45,6 @@
 * Aeva Black  
 * Jeremy Stanley (Spec Committee, OpenInfra Foundation, SPI)  
 * Lars Francke (Stackable)  
-
-</details>
 
 ## Notes
 

--- a/cyber-resilience-sig/minutes/2025-05-26-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-05-26-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  26 May 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-05-26
+Approved: 2025-06-09
+---
+
 ##  Agenda
 | Min | Agenda Topics | Moderator |
 | --: | ----- | --- |
@@ -15,8 +22,7 @@
 |  50 | FAQ TF update | FAQ TF leads |
 |  55 | AOB | |
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
 
 * Tobie Langel (UnlockOpen/Eclipse Foundation)  
 * Juan Rico (Eclipse Foundation)  
@@ -39,9 +45,9 @@
 * Salve J. Nilsen (CPANSec)  
 * Dirk-Willem van Gulik (ASF) *\-- arrived late*
  
-</details>
 
-## Notes
+
+## Minutes
 
 ### Welcome & approve previous minutes
 

--- a/cyber-resilience-sig/minutes/2025-06-09-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-06-09-mom-cyber-resilience-sig.md
@@ -1,4 +1,11 @@
-###  9 June 2025
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ✅ Approved
+Date: 2025-06-09
+Approved: 2025-06-23
+---
+
 ##  Agenda
 
 | Min | Agenda Topics | Moderator |
@@ -24,8 +31,7 @@
 - [X] Start thread with volunteers for BSI/FSFE questionnaire
 
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
 
 * Tobie Langel (UnlockOpen/Eclipse Foundation)  
 * Juan Rico (Eclipse Foundation)  
@@ -50,7 +56,7 @@
 * Simon Phipps (SWH/Meshed Insights)  
 * Æva Black
 
-</details>
+
 
 
 ## Minutes

--- a/cyber-resilience-sig/minutes/2025-06-23-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-06-23-mom-cyber-resilience-sig.md
@@ -1,6 +1,11 @@
-###  23 June 2025
-##  Agenda
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: ⚠️ Draft
+Date: 2025-06-23
+---
 
+##  Agenda
 
 | Min | Agenda Topics | Moderator |
 | --: | ----- | --- |
@@ -25,11 +30,111 @@
 - [X] Add missing volunteers to Vulnerability Handling TF GH team.
 - [ ] Close [work on BSI/FSFE questionnaire](https://github.com/orcwg/cra-hub/labels/Questionnaire).
 
-<details>
-<summary><b>Participants </b></summary>
+## Attendees
 
+* Tobie Langel (UnlockOpen / Eclipse Foundation)  
+* Mathias Schindler (GitHub)  
+* Dave Baker (Red Hat)  
+* Timo Perälä (Nokia)  
+* Becky Hepper (Seagate)  
+* Juan Rico (Eclipse Foundation)  
+* Lenny Moskalyk (Drupal Association)  
+* Jakub Zelenka (PHP Foundation)  
+* Henry Haverinen (Cyberismo)  
+* Shanda Giacomoni (Eclipse Foundation)  
+* Victor Roland (Obeo)  
+* Jonne Soininen (Nokia)  
+* Marty Haught (Ruby Central)  
+* Dirk-Willem van Gulik (ASF)  
+* Jan Westerkamp (iJUG)  
+* Æva Black (Independent)  
+* Marta Rybczynska (Eclipse Foundations)  
+* Alistair Woodman (Erlang Ecosystem Foundation (EEF))  
+* Olle E. Johansson (Edvina, OWASP)  
+* Maxim Baele (OWASP)  
+* Jeremy Stanley (OpenInfra Foundation, SPI)  
+* Friedrich Vandenberghe (imec)  
+* Daniel Thompson-Yvetot (Tauri)
 
-</details>
+## Minutes
+
+### Welcome & approve previous minutes
+
+* Minutes approved and merged.  
+* https://github.com/orcwg/orcwg/pull/116
+
+### Pending action items from last sig call 
+
+* Open [PR](https://github.com/orcwg/orcwg/pull/127) to add statements on CVEs to deliverables plan & get SIG started on this  
+  * https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/coordination/enisa/deliverable-2-6.md  
+  * https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/coordination/enisa/deliverable-2-6-orcwg-csa-revision-feedback.pdf  
+*  Continue work on infrastructure facilitating coordination around standardization.  
+  * Weekly emails continue  
+  * Not much progress outside of that  
+  * Positive feedback from the SIG on those emails  
+*  Organize first Vulnerability Handling TF call.  
+  * More later in the call  
+*  Add missing volunteers to Vulnerability Handling TF GH team.  
+  * Done  
+*  Close [work on BSI/FSFE questionnaire](https://github.com/orcwg/cra-hub/labels/Questionnaire).  
+  * Should I close or merge the open pull requests \- waiting on Roman / Vick
+
+### Welcome new senior policy advisor
+
+* Ciarán O'Riordan joining Eclipse Foundation as Senior Policy Advisor
+
+### Steering & spec committee updates
+
+* Steering committee:  
+  * Discussed input to PT3  
+  * Discuss CRA expert group update  
+  * Discussed marketing updates  
+    * Shanda provided a bit of additional context \+ info about [this week’s meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MHJtaWZybjQ0dmQ1YjBna3VkdnVrMmhxdjggY183ZGI4ZTNmMTNjNGZhYzk4NDEwMzkxOGE5N2M3MDRiYjFkNjE5ZGEwZmRiNjZkMzNmMTc0Nzg0OWI2MDIwYWVhQGc&tmsrc=c_7db8e3f13c4fac984103918a97c704bb1d619da0fdb66d33f1747849b6020aea%40group.calendar.google.com%20%20)  
+* Spec Committee  
+  * Discussed PT 1 & PT 3 input  
+  * Discussed CEN/CENELEC in person meeting  
+  * Discussed scope of standards (essential requirements)  
+  * Discussed contribution to PT3  
+  * No vote on anything in the specs meeting other than approving the minutes from may's meeting 
+
+### CRA Expert Group updates
+
+* Short update on last meetings (already sheridan previous SIG) group of  
+* Shipped our related deliverables:  
+  * [Comments to draft of open source EU Guidance](https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/deliverables.md#27-comments-to-eu-guidance-on-open-source) (not public)  
+  * [Contribution on Open source hardware](https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-3.md)
+
+### ESOs updates
+
+* Shared CEN/CENELEC meeting updates  
+* Cancellation of PT3 Annex C on open source ([canceled our deliverable accordingly](https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-4.md))  
+* Separate policy group created at ETSI to respond to Commission input requests  
+  * E.g. 1025  
+  * Omnibus, etc.
+
+### Vulnerability Handling TF update
+
+* [Minutes](https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/minutes/vulnerability-handling-task-force/2025-06-19-mom-vulnerability-handling-tf.md)  
+* [SIG Deliverables plan](https://github.com/orcwg/orcwg/blob/main/cyber-resilience-sig/deliverables.md)  
+* [Bi-weekly call](https://github.com/orcwg/orcwg/blob/main/MEETINGS.md#vulnerability-handling-task-force-call)  
+* Folks to provide input on topics they’d like addressed  
+* Agreement to focus on valuable deliverables, regardless of context where they’d be used.
+
+### Resource Inventory TF update
+
+* Nothing to report  
+* Tobie commits to completing final draft by EOM
+
+### FAQ TF update
+
+* No update  
+* Call this Friday
+
+### AOB
+
+* Link for CRA Monday happening after this call: [https://eclipse.zoom.us/j/4904674754?omn=89584971434\&jst=3](https://eclipse.zoom.us/j/4904674754?omn=89584971434&jst=3)   
+* Previous CRA Monday calls: [https://github.com/orcwg/orcwg/tree/main/events/cra-mondays](https://github.com/orcwg/orcwg/tree/main/events/cra-mondays) and Youtube playlist: https://www.youtube.com/playlist?list=PLy7t4z5SYNaT-DjqGR0ORSSZGZYW8qmRs
+
 
 [SIG Leads]: https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig#leads
 [ESO Liaisons]: https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig#cen-cenelec-wg-9

--- a/cyber-resilience-sig/minutes/2025-07-07-mom-cyber-resilience-sig.md
+++ b/cyber-resilience-sig/minutes/2025-07-07-mom-cyber-resilience-sig.md
@@ -1,0 +1,41 @@
+---
+SIG: Cyber Resilience SIG
+Document type: Minutes
+Status: 🗓️ Proposed agenda
+Date: 2025-07-07
+---
+
+##  Agenda
+
+
+| Min | Agenda Topics | Moderator |
+| --: | ----- | --- |
+|   0 | Welcome & approve [previous minutes](#) |  |
+|   5 | [Pending action items](#pending-action-items) from last SIG call |  |
+|  10 | Steering & Spec Committee updates | [SIG Leads][] |
+|  15 | | |
+|  20 | CRA Expert Group updates | [Expert Group Liaisons][] |
+|  25 | ESOs updates | [ESO Liaisons][] |
+|  30 | | |
+|  35 | Vulnerability Handling TF update | Vulnerability Handling TF leads |
+|  40 | Resource Inventory TF update ([#228](https://github.com/orcwg/cra-hub/pull/228)) | Inventory TF leads |
+|  45 | FAQ TF update | FAQ TF leads |
+|  50 | | |
+|  55 | AOB | |
+
+## Pending action items
+
+- [ ] Continue work on infrastructure facilitating coordination around standardization.
+- [ ] Close [work on BSI/FSFE questionnaire](https://github.com/orcwg/cra-hub/labels/Questionnaire).
+- [ ] Complete final draft of Resources Inventory.
+
+## Attendees
+
+
+
+
+[SIG Leads]: https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig#leads
+[ESO Liaisons]: https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig#cen-cenelec-wg-9
+[Expert Group Liaisons]: https://github.com/orcwg/orcwg/tree/main/cyber-resilience-sig#cra-expert-group
+
+  


### PR DESCRIPTION
- Leverage front-matter to provide meta data information about minutes
- Clean-up past minutes
- Add draft minutes for June 23 SIG call
- Add proposed agenda for July 7 SIG call

The idea behind this change is to make it easier to share the minutes directly on GitHub (and not as a pull request) after the call, while still making sure folks are aware that those minutes haven't been approved by the SIG (by leveraging the front matter.)