### PR TITLE
Remove timeline section from deliverables.md

### DIFF
--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -77,53 +77,6 @@ flowchart LR
 
 _Note that the [Cyber Resilience SIG][SIG] is empowered to create additional white papers to address pressing issues, support existing deliverables, or provided input to the [European Commission][EU Commission], [ENISA][], the [CRA Expert Group][], the [European Standards Organisations][ESOs], [Market Surveillance Authorities][Market Surveillance], or any other relevant institution._
 
-
-
-
-
-
-<a name=timeline></a>
-
-```mermaid
-gantt
-    title Deliverables Timeline
-    dateFormat  D MMMM YYYY
-    axisFormat %b %Y
-    tickInterval 1month
-
-    section CRA FAQ
-    Collect community FAQs: 1 December 2024, 31 December 2025
-    Develop draft v1.0: 1 February 2025, 31 December 2025
-    Publish v1.0 release candidate: milestone, 1 January 2026, 1d
-    Finalize v1.0: 1 January 2026, 1 February 2026
-    Publish v1.0 final: milestone, 1 February 2026, 1d
-
-    section Inventory
-    Collect community input: done, 1 December 2024, 30 April 2025
-    Develop draft v1.0: done, 1 February 2025, 5 May 2025
-    Publish V1.0 release candidate: done, milestone, 5 May 2025, 1d
-    Finalize v1.0: 5 May 2025, 13 October 2025
-    Publish V1.0 final: milestone, 13 October 2025, 1d
-    Collect feedback: 13 October 2025, 24 November 2025
-    Publish V1.1 final: milestone, 24 November 2025, 1d
-    
-    section Input to draft act on product categories
-    Collect community input: done, 13 March 2025, 18 April 2025
-    Submit input: done, milestone, 18 April 2025, 1d
-
-    section on SBOMs
-
-    section on Due diligence
-
-    section on Attestations
-
-    section Vulnerability management spec
-    Create proposal: done, 1 November 2024, 1 March 2025
-    Contribution proposal to WG: done, milestone, 1 March 2025, 1d
-    Draft v1.0 RC: 1 March 2025, 1 June 2025
-    Publish v1.0 RC: milestone, 1 June 2025, 1d
-```
-
 ## Key stakeholders
 
 The [Cyber Resilience SIG][SIG] intends to collaborate closely with and provide input to the following stakeholders:


### PR DESCRIPTION
Removed the timeline section and associated Gantt chart from the deliverables document.

It wasn't being kept up to date and just ads noise.