### PR TITLE
Formalize deliverables process: submissions, editors, lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Home of the Open Regulatory Compliance (ORC) Working Group of the Eclipse Foundation.
 
-## Cyber Resilience SIG
+## Special Interest Groups (SIGs)
+
+### Cyber Resilience SIG
 
 * [SIG Landing page](./cyber-resilience-sig/)
   * [Task forces](./cyber-resilience-sig#current-task-forces)

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-2.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-2.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.2
 Status: 🚀 Shipped!
+Editors: Timo Perälä
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3
 Date: 2025-05-20

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-2.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-2.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.2
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Timo Perälä
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-4.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-4.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.4
 Status: ❌ Cancelled
+Editors: Timo Perälä
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3
 Date: 2025-05-20

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-5.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-5.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.5
 Status: 🚀 Shipped!
+Editors: Juan Rico, Tobie Langel
 Group: CEN/CENELEC WG 9
 Subgroup: PT 1
 Date: 2025-06-12

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-5.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-5.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.5
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Juan Rico, Tobie Langel
 Group: CEN/CENELEC WG 9
 Subgroup: PT 1

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-9.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-9.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.9
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Juan Rico
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3

--- a/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-9.md
+++ b/cyber-resilience-sig/coordination/cen-cenelec-wg-9/deliverable-2-9.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.9
 Status: 🚀 Shipped!
+Editors: Juan Rico
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3
 Date: 2025-08-04

--- a/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-3.md
+++ b/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-3.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.3
 Status: 🚀 Shipped!
+Editors: Tobie Langel
 Group: CRA Expert Group
 Subgroup: Open Source Workstrand
 Date: 2025-06-14

--- a/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-3.md
+++ b/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-3.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.3
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Tobie Langel
 Group: CRA Expert Group
 Subgroup: Open Source Workstrand

--- a/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-7.md
+++ b/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-7.md
@@ -1,9 +1,10 @@
 ---
 SIG: Cyber Resilience SIG
 Task force:
-Document type: Deliverable
+Document type: Submission
 Number: 2.7
 Status: 🚀 Shipped!
+Editors: Tobie Langel
 Group: CRA Expert Group
 Subgroup: Open Source Workstrand
 Date: 2025-06-20

--- a/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-7.md
+++ b/cyber-resilience-sig/coordination/cra-expert-group/deliverable-2-7.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Submission
 Number: 2.7
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Tobie Langel
 Group: CRA Expert Group
 Subgroup: Open Source Workstrand

--- a/cyber-resilience-sig/coordination/enisa/2026-05-secure-by-design-playbook/deliverable-2-12.md
+++ b/cyber-resilience-sig/coordination/enisa/2026-05-secure-by-design-playbook/deliverable-2-12.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: "2.12"
-Status: 🤔 Under consideration
+Status: 💡 Proposed
 Group: ENISA
 Deadline: 2026-05-15
 ---

--- a/cyber-resilience-sig/coordination/enisa/2026-05-secure-by-design-playbook/deliverable-2-12.md
+++ b/cyber-resilience-sig/coordination/enisa/2026-05-secure-by-design-playbook/deliverable-2-12.md
@@ -1,8 +1,8 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: "2.12"
-Status: 📣 Open consultation
+Status: 🤔 Under consideration
 Group: ENISA
 Deadline: 2026-05-15
 ---

--- a/cyber-resilience-sig/coordination/enisa/deliverable-2-6.md
+++ b/cyber-resilience-sig/coordination/enisa/deliverable-2-6.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.6
 Status: 🚀 Shipped!
+Editors: Tobie Langel
 Group: ENISA
 Date: 2025-06-14
 Shipped: 2025-06-20

--- a/cyber-resilience-sig/coordination/enisa/deliverable-2-6.md
+++ b/cyber-resilience-sig/coordination/enisa/deliverable-2-6.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.6
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Tobie Langel
 Group: ENISA
 Date: 2025-06-14

--- a/cyber-resilience-sig/coordination/european-commission/2025-07-call-for-evidence-1025/deliverable-2-8.md
+++ b/cyber-resilience-sig/coordination/european-commission/2025-07-call-for-evidence-1025/deliverable-2-8.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.8
 Status: 🚀 Shipped!
+Editors: Juan Rico
 Group: European Commission
 Date: 2025-07-21
 Shipped: 2025-07-21

--- a/cyber-resilience-sig/coordination/european-commission/2025-07-call-for-evidence-1025/deliverable-2-8.md
+++ b/cyber-resilience-sig/coordination/european-commission/2025-07-call-for-evidence-1025/deliverable-2-8.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.8
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Juan Rico
 Group: European Commission
 Date: 2025-07-21

--- a/cyber-resilience-sig/coordination/european-commission/2026-02-open-digital-ecosystems-call-for-evidence/deliverable-2-10.md
+++ b/cyber-resilience-sig/coordination/european-commission/2026-02-open-digital-ecosystems-call-for-evidence/deliverable-2-10.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: "2.10"
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Juan Rico
 Group: European Commission
 Date: 2026-02-03

--- a/cyber-resilience-sig/coordination/european-commission/2026-02-open-digital-ecosystems-call-for-evidence/deliverable-2-10.md
+++ b/cyber-resilience-sig/coordination/european-commission/2026-02-open-digital-ecosystems-call-for-evidence/deliverable-2-10.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: "2.10"
 Status: 🚀 Shipped!
+Editors: Juan Rico
 Group: European Commission
 Date: 2026-02-03
 ---

--- a/cyber-resilience-sig/coordination/european-commission/2026-04-call-for-feedback-cra-guidance-package/deliverable-2-11.md
+++ b/cyber-resilience-sig/coordination/european-commission/2026-04-call-for-feedback-cra-guidance-package/deliverable-2-11.md
@@ -1,8 +1,9 @@
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: "2.11"
 Status: ✍️ Work in Progress
+Editors: Juan Rico
 Group: European Commission
 Date: 2026-02-03
 Deadline: 2026-04-13

--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -41,40 +41,41 @@ flowchart LR
 
 ## Deliverables
 
- 📣 Open consultation | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled
+ 🤔 Under consideration | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled
 
-| | Deliverable name | Owner | First draft due | Final draft due |
-|---:|---|---|---|---|
-| **1.** | **Documentation** | | | |
-| ✍️ | 1.1 [CRA FAQ][FAQ] | [FAQ Task Force][] | April 2025 | Dec 2025 |
-| ✍️ | 1.2 [Inventory][] | [Inventory Task Force][] | April 2025 | Sept 2025 |
-| | | | | |
-| **2.** | **Inputs & contributions** | | | |
-| 🚀 | 2.1 [Input to draft implementing act on product categories][input product categories] | [Cyber Resilience SIG][SIG] | March 18, 2025 | April 18, 2025 |
-| 🚀 | 2.2 [Contribution to Vulnerability Handling Standard Clause 4.4][deliverable-2-2] | [Cyber Resilience SIG][SIG] | May 13, 2025 | May 21, 2025 |
-| 🚀 | 2.3 [Contribution to open source EU Guidance on open source hardware][deliverable-2-3] | [Open Source Hardware Task Force][] | May 30, 2025 | June 16, 2025 |
-| ❌ | ~~2.4 [Contribution to Vulnerability Handling Standard Annex C][deliverable-2-4]~~ | ~~[Vulnerability Handling Task Force][]~~ | ~~June 30, 2025~~ | |
-| 🚀 | 2.5 [Comments on CEN/CENELEC PT 1 Standard][deliverable-2-5] | [CEN/CENELEC WG 9 PT 1 liaisons][CEN/CENELEC WG 9 PT 1] | June 12, 2025 |June 12, 2025 |
-| 🚀 | 2.6 [Feedback on Cybersecurity Act (CSA) Revision][deliverable-2-6] | [Cyber Resilience SIG][SIG] | June 14, 2025 | June 20, 2025 |
-| 🚀 | 2.7 [Comments to EU Guidance on open source][deliverable-2-7] | [CRA Expert Group liaisons][CRA Expert Group] | June 18, 2025 | June 20, 2025 |
-| 🚀 | 2.8 [Response to the Call for evidence on the revision of the Standardisation Regulation 1025][deliverable-2-8] | [Cyber Resilience SIG][SIG] | July 5, 2025 | July 21, 2025 |
-| 🚀 | 2.9 [Comments on CEN/CENELEC PT3 Vulnerability Handling Standard][deliverable-2-9] | [Cyber Resilience SIG][SIG] | July 20, 2025 | August 4, 2025 |
-| 🚀 | 2.10 [Contribution to the call for evidence of the Open Digital Ecosystems][deliverable-2-10] | [Cyber Resilience SIG][SIG] | January 15, 2026 | February 3, 2026 |
-| ✍️ | 2.11 [Contribution to the call for feedback of the CRA Guidance Package][deliverable-2-11] | [Cyber Resilience SIG][SIG] | March 2, 2026 | April 12, 2026 |
-| 📣 | 2.12 [Contribution to ENISA Secure by Design and Default Playbook consultation][deliverable-2-12] | [Cyber Resilience SIG][SIG] | | May 14, 2026 |
-| | | | | |
-| **3.** | **White papers** | | | |
-| 🗺️ | 3.1 [White paper on SBOMs][SBOMs] | Dedicated task force |  |  |
-| ✍️ | 3.2 [White paper on due diligence obligation of manufacturers][due diligence] | Dedicated task force | | |
-| 🗺️ | 3.3 [White paper on security attestations][security attestations] | Dedicated task force | | |
-| 🗺️ | 3.4 [White paper on types of open source projects][open source project types] | [Cyber Resilience SIG][SIG] | | |
-| 🚀 | 3.5 [White paper on open source software stewards and CRA][open source stewards cra] | [Vulnerability Handling Task Force][] | | |
-| | | | | |
-| **4.** | **Specifications** | | | |
-| ✍️ | 4.1 [Vulnerability management specification][vulnerability management] | [Cyber Resilience Practices Project][] | March 2025 | |
-| 🗺️ | 4.2 [Specification on principles for cyber resilience for open source development][cyber resilience principles] | [Cyber Resilience Practices Project][] | | |
-| 🗺️ | 4.3 [Specification on generic security requirements for open source components][generic security requirements] | [Cyber Resilience Practices Project][] | | |
-| 🗺️ | 4.4 [Security policy for open source software stewards][security policy] | [Cyber Resilience Practices Project][] | | |
+| | Deliverable name | Owner | Editor | First draft due | Final draft due |
+|---:|---|---|---|---|---|
+| **1.** | **Documentation** | | | | |
+| ✍️ | 1.1 [CRA FAQ][FAQ] | [FAQ Task Force][] | Tobie Langel | April 2025 | June 2026 |
+| ✍️ | 1.2 [Inventory][] | [Inventory Task Force][] | Maxim Baele, Tobie Langel | April 2025 | June 2026 |
+| | | | | | |
+| **2.** | **Submissions** | | | | |
+| 🚀 | 2.1 [Input to draft implementing act on product categories][input product categories] | [Cyber Resilience SIG][SIG] | Tobie Langel | March 18, 2025 | April 18, 2025 |
+| 🚀 | 2.2 [Contribution to Vulnerability Handling Standard Clause 4.4][deliverable-2-2] | [Cyber Resilience SIG][SIG] | Timo Perälä | May 13, 2025 | May 21, 2025 |
+| 🚀 | 2.3 [Contribution to open source EU Guidance on open source hardware][deliverable-2-3] | [Open Source Hardware Task Force][] | Tobie Langel | May 30, 2025 | June 16, 2025 |
+| ❌ | ~~2.4 [Contribution to Vulnerability Handling Standard Annex C][deliverable-2-4]~~ | ~~[Vulnerability Handling Task Force][]~~ | ~~Timo Perälä~~ | ~~June 30, 2025~~ | |
+| 🚀 | 2.5 [Comments on CEN/CENELEC PT 1 Standard][deliverable-2-5] | [CEN/CENELEC WG 9 PT 1 liaisons][CEN/CENELEC WG 9 PT 1] | Juan Rico, Tobie Langel | June 12, 2025 |June 12, 2025 |
+| 🚀 | 2.6 [Feedback on Cybersecurity Act (CSA) Revision][deliverable-2-6] | [Cyber Resilience SIG][SIG] | Tobie Langel | June 14, 2025 | June 20, 2025 |
+| 🚀 | 2.7 [Comments to EU Guidance on open source][deliverable-2-7] | [CRA Expert Group liaisons][CRA Expert Group] | Tobie Langel | June 18, 2025 | June 20, 2025 |
+| 🚀 | 2.8 [Response to the Call for evidence on the revision of the Standardisation Regulation 1025][deliverable-2-8] | [Cyber Resilience SIG][SIG] | Juan Rico | July 5, 2025 | July 21, 2025 |
+| 🚀 | 2.9 [Comments on CEN/CENELEC PT3 Vulnerability Handling Standard][deliverable-2-9] | [Cyber Resilience SIG][SIG] | Juan Rico | July 20, 2025 | August 4, 2025 |
+| 🚀 | 2.10 [Contribution to the call for evidence of the Open Digital Ecosystems][deliverable-2-10] | [Cyber Resilience SIG][SIG] | Juan Rico | January 15, 2026 | February 3, 2026 |
+| ✍️ | 2.11 [Contribution to the call for feedback of the CRA Guidance Package][deliverable-2-11] | [Cyber Resilience SIG][SIG] | Juan Rico | March 2, 2026 | April 12, 2026 |
+| 🤔 | 2.12 [Contribution to ENISA Secure by Design and Default Playbook consultation][deliverable-2-12] | [Cyber Resilience SIG][SIG] | | | May 14, 2026 |
+| | | | | | |
+| **3.** | **White papers** | | | | |
+| 🗺️ | 3.1 [White paper on SBOMs][SBOMs] | Dedicated task force | |  |  |
+| ✍️ | 3.2 [White paper on due diligence obligation of manufacturers][due diligence] | Dedicated task force | Timo Perälä | | |
+| 🗺️ | 3.3 [White paper on security attestations][security attestations] | Dedicated task force | | | |
+| 🗺️ | 3.4 [White paper on types of open source projects][open source project types] | [Cyber Resilience SIG][SIG] | | | |
+| 🚀 | 3.5 [White paper on open source software stewards and CRA][open source stewards cra] | [Vulnerability Handling Task Force][] | Mikael Barbero | | |
+| | | | | | |
+| **4.** | **Specifications** | Owner | Maintainers | First draft due | Final draft due |
+
+| ✍️ | 4.1 [Vulnerability management specification][vulnerability management] | [Cyber Resilience Practices Project][] | Mikael Barbero | March 2025 | |
+| 🤔 | 4.2 [Specification on principles for cyber resilience for open source development][cyber resilience principles] | [Cyber Resilience Practices Project][] | | | |
+| 🤔 | 4.3 [Specification on generic security requirements for open source components][generic security requirements] | [Cyber Resilience Practices Project][] | | | |
+| 🤔 | 4.4 [Security policy for open source software stewards][security policy] | [Cyber Resilience Practices Project][] | | | |
 
 _Note that the [Cyber Resilience SIG][SIG] is empowered to create additional white papers to address pressing issues, support existing deliverables, or provided input to the [European Commission][EU Commission], [ENISA][], the [CRA Expert Group][], the [European Standards Organisations][ESOs], [Market Surveillance Authorities][Market Surveillance], or any other relevant institution._
 

--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -41,7 +41,7 @@ flowchart LR
 
 ## Deliverables
 
- 🤔 Under consideration | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled
+ 💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled
 
 | | Deliverable name | Owner | Editor | First draft due | Final draft due |
 |---:|---|---|---|---|---|
@@ -61,7 +61,7 @@ flowchart LR
 | 🚀 | 2.9 [Comments on CEN/CENELEC PT3 Vulnerability Handling Standard][deliverable-2-9] | [Cyber Resilience SIG][SIG] | Juan Rico | July 20, 2025 | August 4, 2025 |
 | 🚀 | 2.10 [Contribution to the call for evidence of the Open Digital Ecosystems][deliverable-2-10] | [Cyber Resilience SIG][SIG] | Juan Rico | January 15, 2026 | February 3, 2026 |
 | ✍️ | 2.11 [Contribution to the call for feedback of the CRA Guidance Package][deliverable-2-11] | [Cyber Resilience SIG][SIG] | Juan Rico | March 2, 2026 | April 12, 2026 |
-| 🤔 | 2.12 [Contribution to ENISA Secure by Design and Default Playbook consultation][deliverable-2-12] | [Cyber Resilience SIG][SIG] | | | May 14, 2026 |
+| 💡 | 2.12 [Contribution to ENISA Secure by Design and Default Playbook consultation][deliverable-2-12] | [Cyber Resilience SIG][SIG] | | | May 14, 2026 |
 | | | | | | |
 | **3.** | **White papers** | | | | |
 | 🗺️ | 3.1 [White paper on SBOMs][SBOMs] | Dedicated task force | |  |  |
@@ -73,9 +73,9 @@ flowchart LR
 | **4.** | **Specifications** | Owner | Maintainers | First draft due | Final draft due |
 
 | ✍️ | 4.1 [Vulnerability management specification][vulnerability management] | [Cyber Resilience Practices Project][] | Mikael Barbero | March 2025 | |
-| 🤔 | 4.2 [Specification on principles for cyber resilience for open source development][cyber resilience principles] | [Cyber Resilience Practices Project][] | | | |
-| 🤔 | 4.3 [Specification on generic security requirements for open source components][generic security requirements] | [Cyber Resilience Practices Project][] | | | |
-| 🤔 | 4.4 [Security policy for open source software stewards][security policy] | [Cyber Resilience Practices Project][] | | | |
+| 💡 | 4.2 [Specification on principles for cyber resilience for open source development][cyber resilience principles] | [Cyber Resilience Practices Project][] | | | |
+| 💡 | 4.3 [Specification on generic security requirements for open source components][generic security requirements] | [Cyber Resilience Practices Project][] | | | |
+| 💡 | 4.4 [Security policy for open source software stewards][security policy] | [Cyber Resilience Practices Project][] | | | |
 
 _Note that the [Cyber Resilience SIG][SIG] is empowered to create additional white papers to address pressing issues, support existing deliverables, or provided input to the [European Commission][EU Commission], [ENISA][], the [CRA Expert Group][], the [European Standards Organisations][ESOs], [Market Surveillance Authorities][Market Surveillance], or any other relevant institution._
 

--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -41,7 +41,7 @@ flowchart LR
 
 ## Deliverables
 
- 💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled
+ 💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled
 
 | | Deliverable name | Owner | Editor | First draft due | Final draft due |
 |---:|---|---|---|---|---|

--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -41,7 +41,7 @@ flowchart LR
 
 ## Deliverables
 
- 💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled
+ 💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🔒 Pending review | 🚀 Shipped | ❌ Cancelled
 
 | | Deliverable name | Owner | Editor | First draft due | Final draft due |
 |---:|---|---|---|---|---|

--- a/cyber-resilience-sig/deliverables.md
+++ b/cyber-resilience-sig/deliverables.md
@@ -71,7 +71,6 @@ flowchart LR
 | 🚀 | 3.5 [White paper on open source software stewards and CRA][open source stewards cra] | [Vulnerability Handling Task Force][] | Mikael Barbero | | |
 | | | | | | |
 | **4.** | **Specifications** | Owner | Maintainers | First draft due | Final draft due |
-
 | ✍️ | 4.1 [Vulnerability management specification][vulnerability management] | [Cyber Resilience Practices Project][] | Mikael Barbero | March 2025 | |
 | 💡 | 4.2 [Specification on principles for cyber resilience for open source development][cyber resilience principles] | [Cyber Resilience Practices Project][] | | | |
 | 💡 | 4.3 [Specification on generic security requirements for open source components][generic security requirements] | [Cyber Resilience Practices Project][] | | | |

--- a/cyber-resilience-sig/proposed-specs/cyber-resilience-principles.md
+++ b/cyber-resilience-sig/proposed-specs/cyber-resilience-principles.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.2
-Status: 🤔 Under consideration
+Status: 💡 Proposed
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0

--- a/cyber-resilience-sig/proposed-specs/cyber-resilience-principles.md
+++ b/cyber-resilience-sig/proposed-specs/cyber-resilience-principles.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.2
-Status: 🗺️ Planned
+Status: 🤔 Under consideration
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0
@@ -12,7 +12,7 @@ Final license: EFSL
 
 # Specification on principles for cyber resilience for open source
 
-## Description
+## Abstract
 
 This specification is intended address the requirements spelled out in [Annex I, Part I, point (1)][] but specifically targeted at the development of open source components and with a focus on the due diligence obligations of manufacturers. It will build on the white papers on [SBOMs][], [due diligence][], and [security attestations][] mentioned above.
 

--- a/cyber-resilience-sig/proposed-specs/generic-security-requirements.md
+++ b/cyber-resilience-sig/proposed-specs/generic-security-requirements.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.3
-Status: 🗺️ Planned
+Status: 🤔 Under consideration
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0
@@ -12,7 +12,7 @@ Final license: EFSL
 
 # Specification on generic security requirements for open source components
 
-## Description
+## Abstract
 
 This specification is intended to addresses the requirements spelled out in [Annex I, Part I, point (2)][] but specifically targeted at open source components and with a focus on the due diligence obligations of manufacturers. It will build on the white papers on [SBOMs][], [due diligence][], and [security attestations][] mentioned above and work closely with the [Specification on principles for cyber resilience for open source development][cyber resilience principles] mentioned above.
 

--- a/cyber-resilience-sig/proposed-specs/generic-security-requirements.md
+++ b/cyber-resilience-sig/proposed-specs/generic-security-requirements.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.3
-Status: 🤔 Under consideration
+Status: 💡 Proposed
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0

--- a/cyber-resilience-sig/proposed-specs/security-policy.md
+++ b/cyber-resilience-sig/proposed-specs/security-policy.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.4
-Status: 🗺️ Planned
+Status: 🤔 Under consideration
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0
@@ -12,7 +12,7 @@ Final license: EFSL
 
 # Security policy for open source software stewards
 
-## Description
+## Abstract
 
 [Article 24(1)][] of the CRA states that _"open-source software stewards shall put in place and document in a verifiable manner a cybersecurity policy to foster the development of a secure product with digital elements as well as an effective handling of vulnerabilities by the developers of that product."_ This specification will help open source software stewards meet their obligations by specifying minimum requirements that stewards must implement to meet them and provide a structure or format to document their cybersecurity  policy, possibly in a machine-readable way.
 

--- a/cyber-resilience-sig/proposed-specs/security-policy.md
+++ b/cyber-resilience-sig/proposed-specs/security-policy.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: Specification
 Number: 4.4
-Status: 🤔 Under consideration
+Status: 💡 Proposed
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0

--- a/cyber-resilience-sig/whitepapers/due-diligence.md
+++ b/cyber-resilience-sig/whitepapers/due-diligence.md
@@ -4,6 +4,7 @@ Task force:
 Document type: White paper
 Number: 3.2
 Status: 🗺️ Planned
+Editors: Timo Perälä
 Input to: EU Guidance, Implementing Act, Harmonised standards
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0

--- a/cyber-resilience-sig/whitepapers/stewards-and-cra.md
+++ b/cyber-resilience-sig/whitepapers/stewards-and-cra.md
@@ -3,7 +3,7 @@ SIG: Cyber Resilience SIG
 Task force:
 Document type: White paper
 Number: 3.5
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Mikaël Barbero
 Input to: EU Guidance, Implementing Act, Harmonised standards
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance

--- a/cyber-resilience-sig/whitepapers/stewards-and-cra.md
+++ b/cyber-resilience-sig/whitepapers/stewards-and-cra.md
@@ -4,6 +4,7 @@ Task force:
 Document type: White paper
 Number: 3.5
 Status: 🚀 Shipped!
+Editors: Mikaël Barbero
 Input to: EU Guidance, Implementing Act, Harmonised standards
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0

--- a/document-metadata.md
+++ b/document-metadata.md
@@ -20,7 +20,7 @@ Every content document declares a `Document type`. The valid values are:
 | ---------------------- | ---------------------------------------------------------------- |
 | `Minutes`              | [Minutes](#minutes)                                              |
 | `Liaison meeting notes`| [Liaison meeting notes](#liaison-meeting-notes)                  |
-| `Deliverable`          | [Deliverable](#deliverable)                                      |
+| `Submission`           | [Submission](#submission)                                        |
 | `White paper`          | [White paper](#white-paper)                                      |
 | `Specification`        | [Specification](#specification)                                  |
 
@@ -36,7 +36,7 @@ For meetings of the SIG, a task force, or a governance committee. Notes from mee
 | SIG            | `Cyber Resilience SIG` \| `AI Policy and Compliance SIG` | Required for SIG meetings or for meetings of their task forces |
 | Task force     | Name of the task force                               |                                                                |
 | Committee      | `Steering Committee` \| `Specification Committee`    | Required for governance meetings                               |
-| Status*        | `🗓️ Proposed agenda` \| `📝 Draft` \| `✅ Approved` |                                                                |
+| Status*        | See [Meeting notes lifecycle](working-mode.md#meeting-notes-lifecycle) |                                                                |
 | Date*          | `YYYY-MM-DD`                                         | Date of the meeting                                            |
 | Approved       | `YYYY-MM-DD`                                         | Date the minutes were approved. Set when `Status` becomes `✅ Approved` |
 
@@ -114,7 +114,7 @@ File naming: `YYYY-MM-DD-[descriptor]-meeting-notes.md` in `[sig]/coordination/[
 
 ## Deliverables
 
-Documents the working group produces as output: contributions to external stakeholders ([Deliverable](#deliverable)), analytical white papers
+Documents the working group produces as output: submissions to external stakeholders ([Submission](#submission)), analytical white papers
 ([White paper](#white-paper)), and normative technical specifications ([Specification](#specification)). All three share a common set of fields
 and are tracked in `[sig]/deliverables.md`.
 
@@ -124,11 +124,11 @@ Every deliverable carries these fields:
 
 | Field          | Value                                                | Notes                                              |
 | -------------- | ---------------------------------------------------- | -------------------------------------------------- |
-| Document type* | `Deliverable` \| `White paper` \| `Specification`    |                                                    |
+| Document type* | `Submission` \| `White paper` \| `Specification`     |                                                    |
 | SIG*           | `Cyber Resilience SIG` \| `AI Policy and Compliance SIG` |                                                    |
 | Task force     | Name of the task force                               | If produced by a TF                                |
 | Number*        | E.g. `2.5`                                           | Matches the deliverables plan                      |
-| Status*        | `📣 Open consultation` \| `🗺️ Planned` \| `✍️ Work in Progress` \| `🚀 Shipped!` \| `❌ Cancelled` |                                                    |
+| Status*        | See [Deliverables lifecycle](working-mode.md#deliverables-lifecycle) |                                                    |
 | Date           | `YYYY-MM-DD`                                         | Date work on the document started                  |
 | Deadline       | `YYYY-MM-DD`                                         | Deadline by which the document must be completed (e.g. consultation closing date) |
 | Shipped        | `YYYY-MM-DD`                                         | Date the document was shipped. Set when `Status` becomes `🚀 Shipped!` |
@@ -136,23 +136,25 @@ Every deliverable carries these fields:
 
 Each `Document type` adds its own fields below.
 
-### Deliverable
+### Submission
 
-A unit of output contributed to an external stakeholder.
+A unit of output submitted to an external stakeholder (e.g. comments, contributions, feedback, responses).
 
 Adds these fields to the [common set](#common-fields):
 
 | Field    | Value                                                | Notes              |
 | -------- | ---------------------------------------------------- | ------------------ |
+| Editors  | Comma-separated list of names                        | Required once `Status` is `✍️ Work in Progress` or beyond. See [Editors](working-mode.md#editors). |
 | Group*   | One of the SIG's or WG's current liaisons.           | Target stakeholder |
 | Subgroup | E.g. `PT 3`, `Open Source Workstrand`                |                    |
 
 ```yaml
 ---
 SIG: Cyber Resilience SIG
-Document type: Deliverable
+Document type: Submission
 Number: 2.5
 Status: 🚀 Shipped!
+Editors: Juan Rico, Tobie Langel
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3
 Date: 2025-06-11
@@ -170,6 +172,7 @@ Adds these fields to the [common set](#common-fields):
 
 | Field              | Value                          | Notes                |
 | ------------------ | ------------------------------ | -------------------- |
+| Editors            | Comma-separated list of names  | Required once `Status` is `✍️ Work in Progress` or beyond. See [Editors](working-mode.md#editors). |
 | Input to*          | Free-text list                 | Intended consumers   |
 | Relevant liaisons* | Free-text list                 | Liaison groups       |
 | License*           | [SPDX identifier](https://spdx.org/licenses/), e.g. `CC-BY-4.0` |                      |
@@ -180,6 +183,7 @@ SIG: Cyber Resilience SIG
 Document type: White paper
 Number: 3.5
 Status: 🚀 Shipped!
+Editors: Mikaël Barbero
 Input to: EU Guidance, Implementing Act, Harmonised standards
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0
@@ -190,12 +194,17 @@ Located in `[sig]/whitepapers/`.
 
 ### Specification
 
-A normative technical specification. Same fields as a [White paper](#white-paper),
-plus one:
+A normative technical specification.
 
-| Field          | Value         | Notes                                            |
-| -------------- | ------------- | ------------------------------------------------ |
-| Final license* | [SPDX identifier](https://spdx.org/licenses/), e.g. `EFSL` | License the spec will carry once finalized |
+Adds these fields to the [common set](#common-fields):
+
+| Field              | Value                          | Notes                |
+| ------------------ | ------------------------------ | -------------------- |
+| Maintainers        | Comma-separated list of names  | Project maintainers responsible for the spec. Specifications use `Maintainers` rather than `Editors` since they are developed by an [Eclipse open source project](working-mode.md#deliverables). |
+| Input to*          | Free-text list                 | Intended consumers   |
+| Relevant liaisons* | Free-text list                 | Liaison groups       |
+| License*           | [SPDX identifier](https://spdx.org/licenses/), e.g. `CC-BY-4.0` | License of the working draft |
+| Final license*     | [SPDX identifier](https://spdx.org/licenses/), e.g. `EFSL` | License the spec will carry once finalized |
 
 ```yaml
 ---
@@ -203,6 +212,7 @@ SIG: Cyber Resilience SIG
 Document type: Specification
 Number: 4.2
 Status: 🗺️ Planned
+Maintainers: Mikaël Barbero
 Input to: ISO
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance
 License: CC-BY-4.0 OR Apache-2.0

--- a/document-metadata.md
+++ b/document-metadata.md
@@ -131,7 +131,7 @@ Every deliverable carries these fields:
 | Status*        | See [Deliverables lifecycle](working-mode.md#deliverables-lifecycle) |                                                    |
 | Date           | `YYYY-MM-DD`                                         | Date work on the document started                  |
 | Deadline       | `YYYY-MM-DD`                                         | Deadline by which the document must be completed (e.g. consultation closing date) |
-| Shipped        | `YYYY-MM-DD`                                         | Date the document was shipped. Set when `Status` becomes `🚀 Shipped!` |
+| Shipped        | `YYYY-MM-DD`                                         | Date the document was shipped. Set when `Status` becomes `🚀 Shipped` |
 | Cancelled      | `YYYY-MM-DD`                                         | Date the document was cancelled. Set when `Status` becomes `❌ Cancelled` |
 
 Each `Document type` adds its own fields below.
@@ -153,7 +153,7 @@ Adds these fields to the [common set](#common-fields):
 SIG: Cyber Resilience SIG
 Document type: Submission
 Number: 2.5
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Juan Rico, Tobie Langel
 Group: CEN/CENELEC WG 9
 Subgroup: PT 3
@@ -182,7 +182,7 @@ Adds these fields to the [common set](#common-fields):
 SIG: Cyber Resilience SIG
 Document type: White paper
 Number: 3.5
-Status: 🚀 Shipped!
+Status: 🚀 Shipped
 Editors: Mikaël Barbero
 Input to: EU Guidance, Implementing Act, Harmonised standards
 Relevant liaisons: EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,16 @@
+# Templates
+
+Starting points for new documents produced by the WG and its SIGs. Each template carries the correct `Document type`, all the required frontmatter fields (per [`document-metadata.md`](../document-metadata.md)), and the structural sections required by the [working mode](../working-mode.md).
+
+| Template | For | File-naming pattern |
+| --- | --- | --- |
+| [`submission.md`](submission.md) | A submission to an external stakeholder — comments, contributions, feedback, or response to a call/consultation. | `deliverable-X-Y.md` (X.Y from the deliverables plan), in `[sig]/coordination/[stakeholder]/` or a dated subfolder. |
+| [`white-paper.md`](white-paper.md) | A standalone analytical white paper. | Descriptive filename in `[sig]/whitepapers/`. |
+| [`meeting-notes.md`](meeting-notes.md) | A meeting agenda → minutes document for a SIG plenary, task force, or governance committee. | `YYYY-MM-DD-mom-[group].md`, in the relevant `minutes/` folder. |
+
+When using a template:
+
+- Replace each `<placeholder>` in the YAML frontmatter with a concrete value, or leave the field empty when it doesn't apply (per the schema rules in `document-metadata.md`).
+- Replace each `[placeholder]` in the body with concrete content (names, titles, dates, headings, etc.).
+- Replace each `> [!TIP]` callout with the content it describes — the callout is an author instruction, not text to keep.
+- Replace each `_TBD: ..._` block with the relevant boilerplate text once finalized.

--- a/templates/meeting-notes.md
+++ b/templates/meeting-notes.md
@@ -1,0 +1,49 @@
+---
+Committee: <Steering Committee | Specification Committee>
+SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
+Task force: <Task force name, e.g. FAQ TF; leave empty if N/A>
+Document type: Minutes
+Status: <🗓️ Proposed agenda | 📝 Draft | ✅ Approved>
+Date: <YYYY-MM-DD, date of the meeting>
+Approved: <YYYY-MM-DD, set when Status becomes ✅ Approved; otherwise leave empty>
+---
+
+## Agenda
+
+| Agenda topic | Moderator | Minutes |
+| --- | --- | :---: |
+| [Topic] | [Name] | [duration] |
+| [Topic] | [Name] | [duration] |
+| AOB |  | 5 |
+
+## Attendees
+
+- [Name] ([Affiliation])
+- [Name] ([Affiliation])
+
+## Minutes
+
+> [!TIP]
+> Summarize discussion points by agenda topic. Do not attribute comments to individuals. Capture group consensus, resolutions, and action items.
+
+### [Topic 1]
+
+- [Discussion summary]
+- [Discussion summary]
+
+### [Topic 2]
+
+- [Discussion summary]
+
+### AOB
+
+- [Any other business]
+
+## Resolutions
+
+- [Resolution, if any]
+
+## Action items
+
+- [ ] [Action item] — [owner]
+- [ ] [Action item] — [owner]

--- a/templates/submission.md
+++ b/templates/submission.md
@@ -3,7 +3,7 @@ SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
 Task force: <Task force name, if produced by a TF; otherwise leave empty>
 Document type: Submission
 Number: "<X.Y from the SIG's deliverables plan, e.g. 2.12>"
-Status: <🤔 Under consideration | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
+Status: <💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
 Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
 Group: <Target stakeholder, e.g. European Commission, CEN/CENELEC WG 9, ENISA>
 Subgroup: <e.g. PT 3, Open Source Workstrand — leave empty or remove if not relevant>

--- a/templates/submission.md
+++ b/templates/submission.md
@@ -3,7 +3,7 @@ SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
 Task force: <Task force name, if produced by a TF; otherwise leave empty>
 Document type: Submission
 Number: "<X.Y from the SIG's deliverables plan, e.g. 2.12>"
-Status: <💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled>
+Status: <💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🔒 Pending review | 🚀 Shipped | ❌ Cancelled>
 Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
 Group: <Target stakeholder, e.g. European Commission, CEN/CENELEC WG 9, ENISA>
 Subgroup: <e.g. PT 3, Open Source Workstrand — leave empty or remove if not relevant>

--- a/templates/submission.md
+++ b/templates/submission.md
@@ -1,0 +1,56 @@
+---
+SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
+Task force: <Task force name, if produced by a TF; otherwise leave empty>
+Document type: Submission
+Number: "<X.Y from the SIG's deliverables plan, e.g. 2.12>"
+Status: <🤔 Under consideration | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
+Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
+Group: <Target stakeholder, e.g. European Commission, CEN/CENELEC WG 9, ENISA>
+Subgroup: <e.g. PT 3, Open Source Workstrand — leave empty or remove if not relevant>
+Date: <YYYY-MM-DD, date work started>
+Deadline: <YYYY-MM-DD, e.g. consultation closing date>
+Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped!; leave empty until then>
+---
+
+# [Title of the submission]
+
+## Request
+
+> [!TIP]
+> The specific call, consultation, or question being responded to, with a link to the original.
+
+## Context
+
+> [!TIP]
+> The background that motivates the contribution and the open source perspective being brought to bear.
+
+## Goals
+
+> [!TIP]
+> What the SIG aims to achieve through this submission.
+
+## [Body]
+
+> [!TIP]
+> Free-form content. Add subsections as needed (e.g. introduction, identified barriers/issues, recommendations, conclusion). For multi-section bodies, structure with `### Subheading` per topic.
+
+
+## Acknowledgments
+
+The following people have contributed to this document, either directly or indirectly (e.g. by drafting, reviewing, or raising questions):
+
+- [Name]
+- [Name]
+
+If you have contributed to this document and aren't properly acknowledged, or if you want to edit or remove your name, please let us know by [opening an issue](https://github.com/orcwg/orcwg/issues/new) and we will address it promptly.
+
+---
+
+> [!TIP]
+> Optional section — include where the recipient may not be familiar with ORC or when the submission is public.
+
+## About the ORC Working Group
+
+The Open Regulatory Compliance Working Group (ORC WG) brings together prominent open source foundations, leading global enterprises, and industry stakeholders to address the growing impact of software regulations on open source. With over 65 members and growing, ORC develops best practices, specifications, and practical resources to help organizations navigate evolving regulatory requirements. Its initial focus is on the European Cyber Resilience Act (CRA), while supporting the long-term security, sustainability, and adoption of open source innovation worldwide.
+
+For more information, visit [orcwg.org](https://orcwg.org).

--- a/templates/submission.md
+++ b/templates/submission.md
@@ -3,13 +3,13 @@ SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
 Task force: <Task force name, if produced by a TF; otherwise leave empty>
 Document type: Submission
 Number: "<X.Y from the SIG's deliverables plan, e.g. 2.12>"
-Status: <💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
+Status: <💡 Proposed | 🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled>
 Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
 Group: <Target stakeholder, e.g. European Commission, CEN/CENELEC WG 9, ENISA>
 Subgroup: <e.g. PT 3, Open Source Workstrand — leave empty or remove if not relevant>
 Date: <YYYY-MM-DD, date work started>
 Deadline: <YYYY-MM-DD, e.g. consultation closing date>
-Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped!; leave empty until then>
+Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped; leave empty until then>
 ---
 
 # [Title of the submission]

--- a/templates/white-paper.md
+++ b/templates/white-paper.md
@@ -1,0 +1,65 @@
+---
+SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
+Task force: <Task force name, if produced by a TF; otherwise leave empty>
+Document type: White paper
+Number: "<X.Y from the SIG's deliverables plan, e.g. 3.5>"
+Status: <🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
+Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
+Input to: <Free-text list of intended consumers, e.g. EU Guidance, Implementing Act, Harmonised standards>
+Relevant liaisons: <Free-text list, e.g. EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance>
+License: <SPDX identifier, e.g. CC-BY-4.0>
+Date: <YYYY-MM-DD, date work started>
+Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped!; leave empty until then>
+---
+
+# [Title of the white paper]
+
+## Abstract
+
+> [!TIP]
+> A concise summary of what this document covers, its scope, and what it does not cover. State any disclaimers up front (e.g. "This document does not constitute legal guidance; it reflects the current understanding of … held by its contributors.").
+
+## Status of this document
+
+This document is a draft and may be updated, replaced, or obsoleted at any time. It is inappropriate to cite this document as anything other than a work in progress. Publication of this draft does not imply endorsement by the Eclipse Foundation, the Open Regulatory Compliance Working Group, or any of its members or contributors.
+
+<!-- When the deliverable reaches 🚀 Shipped!, replace the above with the following:
+
+This document has been approved by the Steering Committee of the Open Regulatory Compliance Working Group and represents the consensus of the working group.
+
+ -->
+
+## Introduction
+
+> [!TIP]
+> Background and motivation.
+
+## [Body sections]
+
+> [!TIP]
+> Add `## Heading` sections for the substantive content. Use `### Subheading` for finer structure.
+
+## References
+
+> [!TIP]
+> Numbered or bulleted list of references.
+
+1. [Reference]
+1. [Reference]
+
+## Acknowledgments
+
+The following individuals have contributed to this document, either directly or indirectly (e.g. by drafting, reviewing, or raising questions):
+
+- [Name]
+- [Name]
+
+If you have contributed to this document and are not properly acknowledged, or if you want to edit or remove your name, please let us know by [opening an issue](https://github.com/orcwg/orcwg/issues/new) and we will address it promptly.
+
+---
+
+## About the ORC Working Group
+
+The Open Regulatory Compliance Working Group (ORC WG) brings together prominent open source foundations, leading global enterprises, and industry stakeholders to address the growing impact of software regulations on open source. With over 65 members and growing, ORC develops best practices, specifications, and practical resources to help organizations navigate evolving regulatory requirements. Its initial focus is on the European Cyber Resilience Act (CRA), while supporting the long-term security, sustainability, and adoption of open source innovation worldwide.
+
+For more information, visit [orcwg.org](https://orcwg.org).

--- a/templates/white-paper.md
+++ b/templates/white-paper.md
@@ -3,13 +3,13 @@ SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
 Task force: <Task force name, if produced by a TF; otherwise leave empty>
 Document type: White paper
 Number: "<X.Y from the SIG's deliverables plan, e.g. 3.5>"
-Status: <🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped! | ❌ Cancelled>
+Status: <🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled>
 Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
 Input to: <Free-text list of intended consumers, e.g. EU Guidance, Implementing Act, Harmonised standards>
 Relevant liaisons: <Free-text list, e.g. EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance>
 License: <SPDX identifier, e.g. CC-BY-4.0>
 Date: <YYYY-MM-DD, date work started>
-Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped!; leave empty until then>
+Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped; leave empty until then>
 ---
 
 # [Title of the white paper]
@@ -23,7 +23,7 @@ Shipped: <YYYY-MM-DD, set when Status becomes 🚀 Shipped!; leave empty until t
 
 This document is a draft and may be updated, replaced, or obsoleted at any time. It is inappropriate to cite this document as anything other than a work in progress. Publication of this draft does not imply endorsement by the Eclipse Foundation, the Open Regulatory Compliance Working Group, or any of its members or contributors.
 
-<!-- When the deliverable reaches 🚀 Shipped!, replace the above with the following:
+<!-- When the deliverable reaches 🚀 Shipped, replace the above with the following:
 
 This document has been approved by the Steering Committee of the Open Regulatory Compliance Working Group and represents the consensus of the working group.
 

--- a/templates/white-paper.md
+++ b/templates/white-paper.md
@@ -3,7 +3,7 @@ SIG: <Cyber Resilience SIG | AI Policy and Compliance SIG>
 Task force: <Task force name, if produced by a TF; otherwise leave empty>
 Document type: White paper
 Number: "<X.Y from the SIG's deliverables plan, e.g. 3.5>"
-Status: <🗺️ Planned | ✍️ Work in Progress | 🚀 Shipped | ❌ Cancelled>
+Status: <🗺️ Planned | ✍️ Work in Progress | 🔒 Pending review | 🚀 Shipped | ❌ Cancelled>
 Editors: <Comma-separated names; required once Status is ✍️ Work in Progress or beyond. Leave empty if not yet appointed.>
 Input to: <Free-text list of intended consumers, e.g. EU Guidance, Implementing Act, Harmonised standards>
 Relevant liaisons: <Free-text list, e.g. EU Commission, CRA Expert Group, CEN/CENELEC, Market Surveillance>

--- a/working-mode.md
+++ b/working-mode.md
@@ -40,11 +40,28 @@ SIGs are empowered to create additional submissions, position papers, or white p
 
 A deliverable moves through the following statuses, recorded in its `Status` field:
 
-- `🤔 Under consideration` — the SIG is considering producing this deliverable but has not yet committed to it (e.g. evaluating whether to respond to an open external consultation).
+- `💡 Proposed` — the deliverable has been proposed but the SIG has not yet committed to producing it (e.g. evaluating whether to respond to an open external consultation).
 - `🗺️ Planned` — the SIG has committed to producing this deliverable but has not yet appointed an editor for it.
 - `✍️ Work in Progress` — an editor has been appointed and work on the deliverable is actively underway.
 - `🚀 Shipped!` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
 - `❌ Cancelled` — the deliverable has been abandoned.
+
+```mermaid
+stateDiagram-v2
+    [*] --> proposed
+    proposed --> planned: SIG commits
+    proposed --> cancelled: abandoned
+    planned --> work_in_progress: editor appointed
+    planned --> cancelled: abandoned
+    work_in_progress --> shipped: approved by the Steering Committee
+    work_in_progress --> cancelled: abandoned
+
+    proposed: 💡 Proposed
+    planned: 🗺️ Planned
+    work_in_progress: ✍️ Work in Progress
+    shipped: 🚀 Shipped!
+    cancelled: ❌ Cancelled
+```
 
 #### Deliverables structure
 

--- a/working-mode.md
+++ b/working-mode.md
@@ -43,7 +43,7 @@ A deliverable moves through the following statuses, recorded in its `Status` fie
 - `💡 Proposed` — the deliverable has been proposed but the SIG has not yet committed to producing it (e.g. evaluating whether to respond to an open external consultation).
 - `🗺️ Planned` — the SIG has committed to producing this deliverable but has not yet appointed an editor for it.
 - `✍️ Work in Progress` — an editor has been appointed and work on the deliverable is actively underway.
-- `🚀 Shipped!` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
+- `🚀 Shipped` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
 - `❌ Cancelled` — the deliverable has been abandoned.
 
 ```mermaid
@@ -59,7 +59,7 @@ stateDiagram-v2
     proposed: 💡 Proposed
     planned: 🗺️ Planned
     work_in_progress: ✍️ Work in Progress
-    shipped: 🚀 Shipped!
+    shipped: 🚀 Shipped
     cancelled: ❌ Cancelled
 ```
 

--- a/working-mode.md
+++ b/working-mode.md
@@ -50,7 +50,7 @@ A deliverable moves through the following statuses, recorded in its `Status` fie
 ```mermaid
 stateDiagram-v2
     [*] --> proposed
-    proposed --> planned: SIG commits
+    proposed --> planned: adopted by SIG
     proposed --> cancelled: abandoned
     planned --> work_in_progress: editor appointed
     planned --> cancelled: abandoned

--- a/working-mode.md
+++ b/working-mode.md
@@ -6,7 +6,11 @@ This document captures how the ORC WG operates. It can be amended or broken down
 
 The ORC WG is subject to its [charter](https://www.eclipse.org/org/workinggroups/open-regulatory-compliance-charter.php) and the various documents it references, in particular: the Eclipse Foundation Working Group [Process](https://www.eclipse.org/org/workinggroups/process.php) and [Operations Guide](https://www.eclipse.org/org/workinggroups/operations.php).
 
-## SIG repository structure
+## Special Interest Groups
+
+The ORC WG organizes its domain-specific work into thematic Special Interest Groups (SIGs), each focused on a specific area of regulation impacting open source. The current SIGs are listed in the [main README](README.md#special-interest-groups-sigs).
+
+## Repository structure
 
 Each SIG has its own root folder at the repository top level (e.g. `cyber-resilience-sig/`). Inside, a SIG is typically organized as follows:
 
@@ -20,9 +24,45 @@ Each SIG has its own root folder at the repository top level (e.g. `cyber-resili
 
 Frontmatter and file name conventions for the files in these folders are defined in [`document-metadata.md`](document-metadata.md). Consistent metadata allows these documents to be ingested elsewhere, for example on the website.
 
-## Task Forces
+## Deliverables
 
-Special Interest Groups of the ORC WG can form task forces that focus on a particular topic for a fixed period of time.
+A substantial part of a SIG's work is responding to external input requests (calls for evidence, consultations, requests for feedback, etc.) through submissions and producing documentation, position papers, and white papers on topics within its scope. These deliverables follow the process and structure defined below. Their metadata schemas are defined in [`document-metadata.md`](document-metadata.md#deliverables).
+
+Normative technical specifications, on the other hand, follow a dedicated process and require an [Eclipse open source project](https://www.eclipse.org/projects/dev_process/) to host these specifications and develop them with guidance from the SIG; see for example the [Cyber Resilience Practices Project](cyber-resilience-sig/README.md#cyber-resilience-practices-project).
+
+### Deliverables lifecycle
+
+Deliverables are added to a SIG's deliverables plan by the SIG itself.
+
+A SIG's deliverables plan must be approved by the [Steering Committee](governance/steering-committee), usually annually. It can be amended throughout the year as needed; for example, to respond to new submission requests.
+
+SIGs are empowered to create additional submissions, position papers, or white papers within their scope to address pressing issues, support existing deliverables, or provide input to their stakeholders or any other relevant institution. The Steering Committee must be informed when additional submissions are created and may decide to amend or cancel them.
+
+A deliverable moves through the following statuses, recorded in its `Status` field:
+
+- `🤔 Under consideration` — the SIG is considering producing this deliverable but has not yet committed to it (e.g. evaluating whether to respond to an open external consultation).
+- `🗺️ Planned` — the SIG has committed to producing this deliverable but has not yet appointed an editor for it.
+- `✍️ Work in Progress` — an editor has been appointed and work on the deliverable is actively underway.
+- `🚀 Shipped!` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
+- `❌ Cancelled` — the deliverable has been abandoned.
+
+### Deliverables structure
+
+Each deliverable type has a canonical structure provided as a template in [`templates/`](templates/):
+
+- **Submissions**: [`templates/submission.md`](templates/submission.md)
+- **White papers** (and position papers): [`templates/white-paper.md`](templates/white-paper.md)
+- **Specifications**: structure is defined by the [Eclipse open source project](#deliverables) hosting them.
+
+## Editors
+
+Each deliverable, other than specifications, must have at least one editor. Editors are appointed by the SIG. They are responsible for advancing their deliverable and for gathering group consensus around it.
+
+Editing requires balancing progress with fidelity to consensus: editors must keep the deliverable moving forward while respecting what they take to be the group's view at any given point. Regardless of the editor's judgment, the deliverable does not formally represent the SIG's or WG's consensus until it is formally approved by the group.
+
+## Task forces
+
+SIGs can form task forces that focus on a particular topic for a fixed period of time.
 
 A task force must have one or more leads, an area of focus, a set of deliverables, and an end date by which it must present its deliverables and recommendations to the SIG and/or request an extension.
 
@@ -51,6 +91,16 @@ Meeting minutes:
 - should be provided in a draft format for comments
 - should be approved at the latest at the beginning of the next meeting
 
+Meeting agendas and minutes follow the structure in [`templates/meeting-notes.md`](templates/meeting-notes.md).
+
 Note: meetings of governing bodies have additional requirements defined in the [relevant documents](#applicable-documents).
+
+### Meeting notes lifecycle
+
+Meeting agendas and minutes move through the following statuses, recorded in the `Status` field:
+
+- `🗓️ Proposed agenda` — a draft agenda for an upcoming meeting, open for membership input.
+- `📝 Draft` — minutes for a meeting that has occurred, available for review before approval.
+- `✅ Approved` — minutes formally approved by the group, typically at the start of the following meeting.
 
 

--- a/working-mode.md
+++ b/working-mode.md
@@ -43,7 +43,8 @@ A deliverable moves through the following statuses, recorded in its `Status` fie
 - `💡 Proposed` — the deliverable has been proposed but the SIG has not yet committed to producing it (e.g. evaluating whether to respond to an open external consultation).
 - `🗺️ Planned` — the SIG has committed to producing this deliverable but has not yet appointed an editor for it.
 - `✍️ Work in Progress` — an editor has been appointed and work on the deliverable is actively underway.
-- `🚀 Shipped` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
+- `🔒 Pending review` — the deliverable is complete and pending review by the Steering Committee. Substantive edits are frozen; editorial edits (typos, formatting, clarifications) remain permitted unless the Committee requires substantive changes.
+- `🚀 Shipped` — the deliverable has been approved by the Steering Committee and submitted (or published).
 - `❌ Cancelled` — the deliverable has been abandoned.
 
 ```mermaid
@@ -53,12 +54,15 @@ stateDiagram-v2
     proposed --> cancelled: abandoned
     planned --> work_in_progress: editor appointed
     planned --> cancelled: abandoned
-    work_in_progress --> shipped: approved by the Steering Committee
+    work_in_progress --> pending_review: finalized and locked
+    pending_review --> shipped: approved by the Steering Committee
+    pending_review --> work_in_progress: edits required by the Steering Committee
     work_in_progress --> cancelled: abandoned
 
     proposed: 💡 Proposed
     planned: 🗺️ Planned
     work_in_progress: ✍️ Work in Progress
+    pending_review: 🔒 Pending review
     shipped: 🚀 Shipped
     cancelled: ❌ Cancelled
 ```

--- a/working-mode.md
+++ b/working-mode.md
@@ -120,4 +120,15 @@ Meeting agendas and minutes move through the following statuses, recorded in the
 - `📝 Draft` — minutes for a meeting that has occurred, available for review before approval.
 - `✅ Approved` — minutes formally approved by the group, typically at the start of the following meeting.
 
+```mermaid
+stateDiagram-v2
+    [*] --> proposed_agenda
+    proposed_agenda --> draft: minutes taken during meeting
+    draft --> approved: minutes approved in follow-up meeting
+
+    proposed_agenda: 🗓️ Proposed agenda
+    draft: 📝 Draft
+    approved: ✅ Approved
+```
+
 

--- a/working-mode.md
+++ b/working-mode.md
@@ -10,7 +10,7 @@ The ORC WG is subject to its [charter](https://www.eclipse.org/org/workinggroups
 
 The ORC WG organizes its domain-specific work into thematic Special Interest Groups (SIGs), each focused on a specific area of regulation impacting open source. The current SIGs are listed in the [main README](README.md#special-interest-groups-sigs).
 
-## Repository structure
+### Repository structure
 
 Each SIG has its own root folder at the repository top level (e.g. `cyber-resilience-sig/`). Inside, a SIG is typically organized as follows:
 
@@ -24,13 +24,13 @@ Each SIG has its own root folder at the repository top level (e.g. `cyber-resili
 
 Frontmatter and file name conventions for the files in these folders are defined in [`document-metadata.md`](document-metadata.md). Consistent metadata allows these documents to be ingested elsewhere, for example on the website.
 
-## Deliverables
+### Deliverables
 
 A substantial part of a SIG's work is responding to external input requests (calls for evidence, consultations, requests for feedback, etc.) through submissions and producing documentation, position papers, and white papers on topics within its scope. These deliverables follow the process and structure defined below. Their metadata schemas are defined in [`document-metadata.md`](document-metadata.md#deliverables).
 
 Normative technical specifications, on the other hand, follow a dedicated process and require an [Eclipse open source project](https://www.eclipse.org/projects/dev_process/) to host these specifications and develop them with guidance from the SIG; see for example the [Cyber Resilience Practices Project](cyber-resilience-sig/README.md#cyber-resilience-practices-project).
 
-### Deliverables lifecycle
+#### Deliverables lifecycle
 
 Deliverables are added to a SIG's deliverables plan by the SIG itself.
 
@@ -46,7 +46,7 @@ A deliverable moves through the following statuses, recorded in its `Status` fie
 - `🚀 Shipped!` — the deliverable has been completed, approved by the Steering Committee, and submitted (or published).
 - `❌ Cancelled` — the deliverable has been abandoned.
 
-### Deliverables structure
+#### Deliverables structure
 
 Each deliverable type has a canonical structure provided as a template in [`templates/`](templates/):
 
@@ -54,13 +54,13 @@ Each deliverable type has a canonical structure provided as a template in [`temp
 - **White papers** (and position papers): [`templates/white-paper.md`](templates/white-paper.md)
 - **Specifications**: structure is defined by the [Eclipse open source project](#deliverables) hosting them.
 
-## Editors
+### Editors
 
 Each deliverable, other than specifications, must have at least one editor. Editors are appointed by the SIG. They are responsible for advancing their deliverable and for gathering group consensus around it.
 
 Editing requires balancing progress with fidelity to consensus: editors must keep the deliverable moving forward while respecting what they take to be the group's view at any given point. Regardless of the editor's judgment, the deliverable does not formally represent the SIG's or WG's consensus until it is formally approved by the group.
 
-## Task forces
+### Task forces
 
 SIGs can form task forces that focus on a particular topic for a fixed period of time.
 


### PR DESCRIPTION
## Summary

Introduces and clarifies several concepts that have been implicit in the working group's practice, and aligns existing documents and the metadata schema accordingly.

The updated working mode document can be read in full [here](https://github.com/orcwg/orcwg/blob/tobie-workmode-update/working-mode.md).

### Submissions

Renames the `Deliverable` document type to `Submission` to better reflect what these documents actually are: units of output submitted to an external stakeholder (comments, contributions, feedback, and responses to calls or consultations). The previous name conflated this specific output type with the broader "deliverable" concept that also covers white papers and specifications.

### Editors

Introduces **editors** as a first-class role. Every deliverable other than a specification must have at least one editor, appointed by the SIG, who is responsible for advancing the document and gathering group consensus around it.

The PR also names the equivalent role for specifications (**maintainers**) distinct because specs are developed inside an [Eclipse open source project](https://www.eclipse.org/projects/dev_process/) that has its own maintainer model.

The working mode notes the tension editors must navigate: keeping work moving forward while staying faithful to the group's evolving view, with the deliverable only formally representing SIG consensus once approved.

### Explicit lifecycles

Two lifecycles are now defined explicitly in the working mode and referenced from the metadata schema, each accompanied by a Mermaid state diagram visualizing the allowed transitions between statuses:

1. **Deliverables lifecycle**, with a new `💡 Proposed` status to capture the (until now implicit) state of a deliverable that has been proposed but that the SIG has not yet committed to (e.g. an open external consultation under review). This replaces the previous practice of using `🗺️  Planned` or `📣 Open consultation` for that state. A new `🔒 Pending review` status is also introduced to capture the gating period between an editor finalizing the deliverable and the Steering Committee approving it — substantive edits are frozen during this stage, though editorial edits remain permitted. `🚀 Shipped!` is also renamed to `🚀 Shipped`.
2. **Meeting notes lifecycle**, formalizing the existing `🗓️  Proposed agenda` → `📝 Draft` → `✅ Approved` flow.

### Templates

Adds canonical templates so authors don't reinvent structure or frontmatter for each new document: one for submissions, one for white papers, and one for meeting notes. Specifications continue to take their structure from the hosting Eclipse project.

### SIGs as a first-class concept

The README and working mode now treat **Special Interest Groups** as the primary organizing unit of the WG, in anticipation of the upcoming AI Policy and Compliance SIG joining the Cyber Resilience SIG.

### Alignment

Existing submissions, white papers, proposed specs, and the SIG's deliverables plan have been updated to use the new type name, carry editors/maintainers where applicable, and use the new lifecycle statuses.
