### PR TITLE
Fill in 2025-11-25 FAQ TF minutes and mark prior minutes as approved

### DIFF
--- a/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-10-17-mom-faq-tf.md
+++ b/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-10-17-mom-faq-tf.md
@@ -2,8 +2,9 @@
 SIG: Cyber Resilience SIG
 Task force: FAQ TF
 Document type: Minutes
-Status: 📝 Draft
+Status: ✅ Approved
 Date: 2025-10-17
+Approved: 2025-11-25
 ---
 
 ##  Agenda

--- a/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-10-31-mom-faq-tf.md
+++ b/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-10-31-mom-faq-tf.md
@@ -2,8 +2,9 @@
 SIG: Cyber Resilience SIG
 Task force: FAQ TF
 Document type: Minutes
-Status: 📝 Draft
+Status: ✅ Approved
 Date: 2025-10-31
+Approved: 2025-11-25
 ---
 
 ##  Agenda

--- a/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-11-11-mom-faq-tf.md
+++ b/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-11-11-mom-faq-tf.md
@@ -2,8 +2,9 @@
 SIG: Cyber Resilience SIG
 Task force: FAQ TF
 Document type: Minutes
-Status: 📝 Draft
+Status: ✅ Approved
 Date: 2025-11-11
+Approved: 2025-11-25
 ---
 
 ##  Agenda
@@ -14,7 +15,7 @@ Date: 2025-11-11
 |   3 | Approve minutes for [October 17](./2025-10-17-mom-faq-tf.md) and [October 31](./2025-10-31-mom-faq-tf.md) | Tobie |
 |   5 | [Pending action items](#pending-action-items) from last TF call | Tobie |
 |  10 | Status update ([roadmap][]) | Tobie |
-|  15 | Discuss new catgories and [nested lists](https://github.com/orcwg/cra.orcwg.org/issues/118) | Tobie |
+|  15 | Discuss new categories and [nested lists](https://github.com/orcwg/cra.orcwg.org/issues/118) | Tobie |
 |  20 | Discuss [callouts in Guidance requests](https://github.com/orcwg/cra.orcwg.org/issues/137) | Tobie |
 |  25 | Discuss skeleton proposal for FAQ governance | Tobie |
 |  30 | | |
@@ -50,10 +51,10 @@ Date: 2025-11-11
 
 * Provided status update ([roadmap][])
 
-### Discuss new catgories and nested lists
+### Discuss new categories and nested lists
 
-* Discussed 
-* Decision to move ahead with implementation
+* Discussed.
+* Decision to move ahead with implementation.
 
 ### Discuss callouts in Guidance requests
 

--- a/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-11-25-mom-faq-tf.md
+++ b/cyber-resilience-sig/task-forces/faq-tf/minutes/2025-11-25-mom-faq-tf.md
@@ -2,7 +2,7 @@
 SIG: Cyber Resilience SIG
 Task force: FAQ TF
 Document type: Minutes
-Status: 🗓️ Proposed agenda
+Status: 📝 Draft
 Date: 2025-11-25
 ---
 
@@ -18,13 +18,62 @@ Date: 2025-11-25
 |  20 | Update on callouts in Guidance requests | Tobie |
 |  25 | Update on skeleton proposal for FAQ governance | Tobie |
 |  30 | [Remote data processing FAQs](https://cra.orcwg.org/faq/remote-processing/) | Tobie |
-|  35 | | |
-|  40 | | |
-|  45 | | |
-|  50 | | |
 |  55 | AOB | |
 
 ## Pending action items
+
+- None
+
+## Participants
+
+* Tobie Langel (UnlockOpen)
+* Jakub Zelenka (PHP Foundation)
+* August Bournique (Bow Shock Consulting)
+* Victor Roland (Obeo)
+* Timo Perälä (Nokia)
+* Juan Rico (Eclipse Foundation) - joining at 15:57
+
+## Minutes
+
+### Welcome & approve agenda
+
+* Agenda approved.
+* No additional AOBs.
+
+### Approve minutes
+
+* No objections to approve minutes for [October 17](./2025-10-17-mom-faq-tf.md), [October 31](./2025-10-31-mom-faq-tf.md), and [November 11](./2025-11-11-mom-faq-tf.md).
+
+### Pending action items from last TF call
+
+* None.
+* No items labeled [high-priority](https://github.com/orcwg/cra-hub/issues?q=state:open%20label:high-priority).
+
+### Status update
+
+* [Roadmap][roadmap].
+
+### Update on new categories and nested lists
+
+* Discussed.
+
+### Update on callouts in Guidance requests
+
+* Discussed.
+
+### Update on skeleton proposal for FAQ governance
+
+* Discussed.
+
+### Remote data processing FAQs
+
+* See [cra.orcwg.org/faq/remote-processing/](https://cra.orcwg.org/faq/remote-processing/).
+
+### AOB
+
+* None.
+
+## Action items
 
 - None
 


### PR DESCRIPTION
Adds participants and minutes content for the 2025-11-25 FAQ TF meeting, and marks the October 17, October 31, and November 11 minutes as approved on that date.